### PR TITLE
Fix missing statsheet css values

### DIFF
--- a/src/main/java/net/rptools/maptool/model/library/builtin/themecss/ThemeCssContext.java
+++ b/src/main/java/net/rptools/maptool/model/library/builtin/themecss/ThemeCssContext.java
@@ -132,4 +132,13 @@ public class ThemeCssContext {
   public ColorCssContext getThemeColor() {
     return themeColor;
   }
+
+  /**
+   * Gets the disabled foreground color CSS.
+   *
+   * @return The disabled foreground color CSS.
+   */
+  public String getForegroundColorDisabled() {
+    return foregroundColorDisabled;
+  }
 }


### PR DESCRIPTION
### Identify the Bug or Feature request

fixes #4145


### Description of the Change
Fix the --mt-theme-color-foreground-disabled variable in stat sheet css


### Possible Drawbacks

Should be none 

### Documentation Notes
Fix the --mt-theme-color-foreground-disabled variable in stat sheet css


### Release Notes
Fix the --mt-theme-color-foreground-disabled variable in stat sheet css

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4146)
<!-- Reviewable:end -->
